### PR TITLE
:rocket: イベントの参加・参加キャンセル機能実装

### DIFF
--- a/app/assets/stylesheets/tickets.scss
+++ b/app/assets/stylesheets/tickets.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the tickets controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,6 +3,8 @@ class EventsController < ApplicationController
 
   def show
     @event = Event.find(params[:id])
+    @ticket = current_user && current_user.tickets.find_by(event: @event)
+    @tickets = @event.tickets.includes(:user).order(:created_at)
   end
 
   def new

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -1,0 +1,22 @@
+class TicketsController < ApplicationController
+  def new
+    raise ActionController::RoutingError, "ログイン状態で TicketsController#new にアクセス"
+  end
+
+  def create
+    event = Event.find(params[:event_id])
+    @ticket = current_user.tickets.build do |t|
+      t.event = event
+      t.comment = params[:ticket][:comment]
+    end
+    if @ticket.save
+      redirect_to event, notice: "このイベントに参加表明しました"
+    end
+  end
+
+  def destroy
+    ticket = current_user.tickets.find_by!(event_id: params[:event_id])
+    ticket.destroy!
+    redirect_to event_path(params[:event_id]), notice: "このイベントの参加をキャンセルしました"
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def url_for_github(user)
+    "https://github.com/#{user.name}"
+  end
 end

--- a/app/helpers/tickets_helper.rb
+++ b/app/helpers/tickets_helper.rb
@@ -1,0 +1,2 @@
+module TicketsHelper
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,5 @@
 class Event < ApplicationRecord
+  has_many :tickets, dependent: :destroy
   belongs_to :owner, class_name: "User"
 
   validates :name, length: { maximum: 50 }, presence: true

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,0 +1,6 @@
+class Ticket < ApplicationRecord
+  belongs_to :user, optional: true
+  belongs_to :event
+
+  validates :comment, length: { maximum: 30 }, allow_blank: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_many :created_events, class_name: "Event", foreign_key: "owner_id"
+  has_many :tickets
 
   def self.find_or_create_from_auth_hash!(auth_hash)
     provider = auth_hash[:provider]

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -16,10 +16,40 @@
     .card.mb-2
       %h5.card-header 主催者
       .card-body
-        = link_to("https://github.com/#{@event.owner.name}", class: "card-link") do
+        = link_to(url_for_github(@event.owner), class: "card-link") do
           = image_tag @event.owner.image_url, width: 50, height: 50
           = "@#{@event.owner.name}"
   .col-4
     - if @event.created_by?(current_user)
       = link_to "イベントを編集する", edit_event_path(@event), class: "btn btn-info btn-lg btn-block"
       = link_to "イベントを削除する", event_path(@event), class: "btn btn-danger btn-lg btn-block", method: :delete, data: {confirm: "本当に削除しますか？"}
+    - if @ticket
+      = link_to "参加をキャンセルする", event_ticket_path(@event, @ticket), method: :delete, class: "btn btn-warning btn-lg btn-block"
+    - elsif logged_in?
+      %button.btn.btn-primary.btn-lg.btn-block{ "data-toggle" => "modal", "data-target" => "#createTicket" }
+        参加する
+      %div.modal.fade#createTicket
+        .modal-dialog
+          .modal-content
+            .modal-header
+              %h4.modal-title#dialogHeader 参加コメント
+              %button.close{ type: "button", "data-dismiss": "modal" } &times;
+            = form_with(model: @event.tickets.build, url: event_tickets_path(@event)) do |f|
+              .modal-body
+                #createTicketErrors
+                = f.text_field :comment, class: "form-control"
+              .modal-footer
+                %button.btn.btn-default{ type: "button", "data-dismiss": "modal" }
+                  キャンセル
+                = f.button "送信", class: "btn btn-primary"
+    - else
+      = link_to "参加する", new_event_ticket_path(@event), class: "btn btn-primary btn-lg btn-block"
+    .card.mb-2
+      %h5.card-header 参加者
+      %ul.list-group.list-group-flush
+        - @tickets.each do |ticket|
+          %li.list-group-item
+            = link_to(url_for_github(ticket.user), class: "card-link") do
+              = image_tag ticket.user.image_url, width: 20, height: 20
+              = "@#{ticket.user.name}"
+            = ticket.comment

--- a/app/views/tickets/create.js.erb
+++ b/app/views/tickets/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById("createTicketErrors").innerHTML = "<%= j render("errors", errors: @event.errors) %>"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,3 +9,5 @@ ja:
         start_at: 開始時間
         end_at: 終了時間
         content: 内容
+      ticket:
+        comment: コメント

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
-  resources :events
   root 'welcome#index'
   get "/auth/:provider/callback" => 'sessions#create'
   delete '/logout' => 'sessions#destroy'
+
+  resources :events do
+    resources :tickets
+  end
 end

--- a/db/migrate/20220821101222_create_tickets.rb
+++ b/db/migrate/20220821101222_create_tickets.rb
@@ -1,0 +1,13 @@
+class CreateTickets < ActiveRecord::Migration[6.1]
+  def change
+    create_table :tickets do |t|
+      t.references :user
+      t.references :event, null: false, foreign_key: true, index: false
+      t.string :comment
+
+      t.timestamps
+    end
+
+    add_index :tickets, %i[event_id user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_16_112531) do
+ActiveRecord::Schema.define(version: 2022_08_21_101222) do
 
   create_table "events", force: :cascade do |t|
     t.bigint "owner_id"
@@ -24,6 +24,16 @@ ActiveRecord::Schema.define(version: 2022_08_16_112531) do
     t.index ["owner_id"], name: "index_events_on_owner_id"
   end
 
+  create_table "tickets", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "event_id", null: false
+    t.string "comment"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["event_id", "user_id"], name: "index_tickets_on_event_id_and_user_id", unique: true
+    t.index ["user_id"], name: "index_tickets_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "provider", null: false
     t.string "uid", null: false
@@ -34,4 +44,5 @@ ActiveRecord::Schema.define(version: 2022_08_16_112531) do
     t.index "\"provider,\", \"uid\"", name: "index_users_on_provider,_and_uid", unique: true
   end
 
+  add_foreign_key "tickets", "events"
 end

--- a/test/controllers/tickets_controller_test.rb
+++ b/test/controllers/tickets_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TicketsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/tickets.yml
+++ b/test/fixtures/tickets.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  event: one
+  comment: MyString
+
+two:
+  user: two
+  event: two
+  comment: MyString

--- a/test/models/ticket_test.rb
+++ b/test/models/ticket_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TicketTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# model作成時のreferencesについて

```sh
bin/rails g model ticket user:references event:references comment
```

```rb
t.references :event, null: false, foreign_key: true, index: false
```

マイグレーションファイルで、`foreign_key: true`とすると外部キー制約が付与される。また上記のように`references`をつけた場合、`event_id`というカラムを作成してくれる

